### PR TITLE
Adds multi-threading to SimpleBreeder 

### DIFF
--- a/src/main/java/com/alphatica/genotick/breeder/SimpleBreeder.java
+++ b/src/main/java/com/alphatica/genotick/breeder/SimpleBreeder.java
@@ -18,7 +18,6 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.Random;
 import java.util.stream.IntStream;
 
 import static com.alphatica.genotick.utility.Assert.gassert;
@@ -26,7 +25,7 @@ import static com.alphatica.genotick.utility.Assert.gassert;
 public class SimpleBreeder implements RobotBreeder {
     private BreederSettings settings;
     private Mutator mutator;
-    private Random random;
+    private RandomGenerator random;
     private final WeightCalculator weightCalculator;
     private final UserOutput output;
 
@@ -79,13 +78,16 @@ public class SimpleBreeder implements RobotBreeder {
     }
 
     private void fillWithRobots(int count, Population population) {
-    	if(count < 32 || !(random instanceof ThreadLocalRandom)) {
-        	fillWithRobotsSync(count, population);
-        		return;
+    	if(count < 32 || random.getSeed() != 0) {
+            fillWithRobotsSync(count, population);
+            return;
     	} else {
-    		int cores =  Math.max(2, Runtime.getRuntime().availableProcessors());
-			int taskSize = (int)Math.ceil((double)count / (double)cores);
-			IntStream.range(0, count).filter(blockIndex -> blockIndex % taskSize == 0).parallel().forEach(blockIndex -> fillWithRobotsSync(Math.min(taskSize, count-blockIndex), population));
+            int cores =  Math.max(2, Runtime.getRuntime().availableProcessors());
+            int taskSize = (int)Math.ceil((double)count / (double)cores);
+            IntStream.range(0, count)
+                .filter(blockIndex -> blockIndex % taskSize == 0)
+                .parallel()
+                .forEach(blockIndex -> fillWithRobotsSync(Math.min(taskSize, count-blockIndex), population));
     	} 
     }
 

--- a/src/main/java/com/alphatica/genotick/breeder/SimpleBreeder.java
+++ b/src/main/java/com/alphatica/genotick/breeder/SimpleBreeder.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ForkJoinPool;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.Random;
 import java.util.stream.IntStream;
 
@@ -78,14 +79,14 @@ public class SimpleBreeder implements RobotBreeder {
     }
 
     private void fillWithRobots(int count, Population population) {
-	    	if(count < 32 || RandomGenerator.getSeed() != 0) {
-		    		fillWithRobotsSync(count, population);
-						return;
-	    	} else {
-		    		int cores =  Math.max(2, Runtime.getRuntime().availableProcessors());
-						int taskSize = (int)Math.ceil((double)count / (double)cores);
-						IntStream.range(0, count).filter(x -> x % taskSize == 0).parallel().forEach(x -> fillWithRobotsSync(Math.min(taskSize, count-x), population));
-	    	} 
+    	if(count < 32 || !(random instanceof ThreadLocalRandom)) {
+        	fillWithRobotsSync(count, population);
+        		return;
+    	} else {
+    		int cores =  Math.max(2, Runtime.getRuntime().availableProcessors());
+			int taskSize = (int)Math.ceil((double)count / (double)cores);
+			IntStream.range(0, count).filter(blockIndex -> blockIndex % taskSize == 0).parallel().forEach(blockIndex -> fillWithRobotsSync(Math.min(taskSize, count-blockIndex), population));
+    	} 
     }
 
     private void createNewRobot(Population population) {

--- a/src/main/java/com/alphatica/genotick/breeder/SimpleBreeder.java
+++ b/src/main/java/com/alphatica/genotick/breeder/SimpleBreeder.java
@@ -11,14 +11,11 @@ import com.alphatica.genotick.population.Robot;
 import com.alphatica.genotick.population.RobotInfo;
 import com.alphatica.genotick.population.RobotSettings;
 import com.alphatica.genotick.ui.UserOutput;
+import com.alphatica.genotick.utility.ParallelTasks;
 
 import java.util.ArrayList;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ForkJoinPool;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.IntStream;
 
 import static com.alphatica.genotick.utility.Assert.gassert;
 
@@ -82,12 +79,7 @@ public class SimpleBreeder implements RobotBreeder {
             fillWithRobotsSync(count, population);
             return;
     	} else {
-            int cores =  Math.max(2, Runtime.getRuntime().availableProcessors());
-            int taskSize = (int)Math.ceil((double)count / (double)cores);
-            IntStream.range(0, count)
-                .filter(blockIndex -> blockIndex % taskSize == 0)
-                .parallel()
-                .forEach(blockIndex -> fillWithRobotsSync(Math.min(taskSize, count-blockIndex), population));
+            ParallelTasks.parallelNumberedTask(count, (subCount) -> fillWithRobotsSync(subCount, population));
     	} 
     }
 

--- a/src/main/java/com/alphatica/genotick/breeder/SimpleBreeder.java
+++ b/src/main/java/com/alphatica/genotick/breeder/SimpleBreeder.java
@@ -13,9 +13,12 @@ import com.alphatica.genotick.population.RobotSettings;
 import com.alphatica.genotick.ui.UserOutput;
 
 import java.util.ArrayList;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinPool;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.IntStream;
 
 import static com.alphatica.genotick.utility.Assert.gassert;
 
@@ -68,10 +71,21 @@ public class SimpleBreeder implements RobotBreeder {
         }
     }
 
-    private void fillWithRobots(int count, Population population) {
+    private void fillWithRobotsSync(int count, Population population) {
         for (int i = 0; i < count; i++) {
             createNewRobot(population);
         }
+    }
+
+    private void fillWithRobots(int count, Population population) {
+	    	if(count < 32 || RandomGenerator.getSeed() != 0) {
+		    		fillWithRobotsSync(count, population);
+						return;
+	    	} else {
+		    		int cores =  Math.max(2, Runtime.getRuntime().availableProcessors());
+						int taskSize = (int)Math.ceil((double)count / (double)cores);
+						IntStream.range(0, count).filter(x -> x % taskSize == 0).parallel().forEach(x -> fillWithRobotsSync(Math.min(taskSize, count-x), population));
+	    	} 
     }
 
     private void createNewRobot(Population population) {

--- a/src/main/java/com/alphatica/genotick/genotick/Main.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Main.java
@@ -86,8 +86,8 @@ public class Main {
         this.canContinue = false;
     }
 
-    private void printError(final ErrorCode error, long elapseTimeSeconds) {
-        System.out.println(format("Program finished with error code %s(%d) in %d seconds", error.toString(), error.getValue(), elapseTimeSeconds));
+    private void printError(final ErrorCode error, long elapsedSeconds) {
+        System.out.println(format("Program finished with error code %s(%d) in %d seconds", error.toString(), error.getValue(), elapsedSeconds));
     }
 
     private void initHelp(Parameters parameters) {

--- a/src/main/java/com/alphatica/genotick/genotick/Main.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Main.java
@@ -34,11 +34,15 @@ public class Main {
     private MainInterface.Session session;
 
     public static void main(String[] args) throws IOException, IllegalAccessException {
+	    	int poolCores = Math.max(Runtime.getRuntime().availableProcessors()*2, 2);
+	    	System.setProperty("java.util.concurrent.ForkJoinPool.common.parallelism", Integer.toString(poolCores));
+	    	
         Main main = new Main();
         main.init(args, null);
     }
 
     public ErrorCode init(String[] args, MainInterface.Session session) throws IOException, IllegalAccessException {
+        long startTime = System.currentTimeMillis();
         this.session = session;
         Parameters parameters = new Parameters(args);
         if (canContinue) {
@@ -68,17 +72,17 @@ public class Main {
         if (canContinue) {
             initSimulation(parameters);
         }
-        printError(error);
+        printError(error, System.currentTimeMillis() - startTime);
         return error;
     }
-
+    
     private void setError(ErrorCode error) {
         this.error = error;
         this.canContinue = false;
     }
 
-    private void printError(final ErrorCode error) {
-        System.out.println(format("Program finished with error code %s(%d)", error.toString(), error.getValue()));
+    private void printError(final ErrorCode error, long elapseTime) {
+        System.out.println(format("Program finished with error code %s(%d) in %d seconds", error.toString(), error.getValue(), (elapseTime/1000)));
     }
 
     private void initHelp(Parameters parameters) {
@@ -215,7 +219,9 @@ public class Main {
         MainAppData data = input.getData(settings.dataDirectory);
         generateMissingData(settings, data);
         MainInterface.SessionResult sessionResult = (session != null) ? session.result : null;
+        long startTime = System.currentTimeMillis();
         simulation.start(settings, data, sessionResult);
+        System.out.println(format("Simulation finished in %d seconds", ((System.currentTimeMillis()-startTime)/1000)));
         setError(ErrorCode.NO_ERROR);
     }
     

--- a/src/main/java/com/alphatica/genotick/genotick/Main.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Main.java
@@ -19,6 +19,7 @@ import com.alphatica.genotick.ui.UserInput;
 import com.alphatica.genotick.ui.UserInputOutputFactory;
 import com.alphatica.genotick.ui.UserOutput;
 import com.alphatica.genotick.utility.TimeCounter;
+import com.alphatica.genotick.utility.ParallelTasks;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
@@ -41,7 +42,7 @@ public class Main {
     }
 
     public ErrorCode init(String[] args, MainInterface.Session session) throws IOException, IllegalAccessException {
-        prepareDefaultThreadPool();
+        ParallelTasks.prepareDefaultThreadPool();
         TimeCounter totalRunTime = new TimeCounter("Total Run Time", false);
         this.session = session;
         Parameters parameters = new Parameters(args);
@@ -74,11 +75,6 @@ public class Main {
         }
         printError(error, totalRunTime.stop(TimeUnit.SECONDS));
         return error;
-    }
-    
-    private void prepareDefaultThreadPool() {
-    	int poolCores = Math.max(Runtime.getRuntime().availableProcessors()*2, 2);
-    	System.setProperty("java.util.concurrent.ForkJoinPool.common.parallelism", Integer.toString(poolCores));
     }
     
     private void setError(ErrorCode error) {

--- a/src/main/java/com/alphatica/genotick/genotick/RandomGenerator.java
+++ b/src/main/java/com/alphatica/genotick/genotick/RandomGenerator.java
@@ -1,24 +1,76 @@
 package com.alphatica.genotick.genotick;
 
+import java.io.Serializable;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.Random;
 
-public class RandomGenerator {
+public class RandomGenerator implements Serializable {
 
-    private RandomGenerator() {}
+    private static final long serialVersionUID = -32164662984L;
 
-    public static Random create(long seed) {
+    Random random;
+    long seed;
+    
+    private RandomGenerator(long requestedSeed) {
         String seedString = System.getenv("GENOTICK_RANDOM_SEED");
         if (seedString != null && !seedString.isEmpty()) {
-            seed = Long.parseLong(seedString);
+            requestedSeed = Long.parseLong(seedString);
         }
         Random random;
-        if (seed != 0) {
+        if (requestedSeed != 0) {
             random = new Random();
-            random.setSeed(seed);
+            random.setSeed(requestedSeed);
         } else {
-            random = ThreadLocalRandom.current();
+            random = null;
         }
-        return random;
+        seed = requestedSeed;
+    }
+    
+    public long getSeed() {
+        return seed;
+    }
+
+    public static RandomGenerator create(long requestedSeed) {
+        return new RandomGenerator(requestedSeed);
+    }
+    
+    public int nextInt() {
+        if(random != null) {
+            return random.nextInt();
+        } else {
+            return ThreadLocalRandom.current().nextInt();
+        }
+    }
+    
+    public int nextInt(int bound) {
+        if(random != null) {
+            return random.nextInt(bound);
+        } else {
+            return ThreadLocalRandom.current().nextInt(bound);
+        }
+    }
+
+    public long nextLong() {
+        if(random != null) {
+            return random.nextLong();
+        } else {
+            return ThreadLocalRandom.current().nextLong();
+        }
+    }
+
+    public double nextDouble() {
+        if(random != null) {
+            return random.nextDouble();
+        } else {
+            return ThreadLocalRandom.current().nextDouble();
+        }
+    }
+    
+    public boolean nextBoolean() {
+        if(random != null) {
+            return random.nextBoolean();
+        } else {
+            return ThreadLocalRandom.current().nextBoolean();
+        }
     }
 }

--- a/src/main/java/com/alphatica/genotick/genotick/RandomGenerator.java
+++ b/src/main/java/com/alphatica/genotick/genotick/RandomGenerator.java
@@ -16,7 +16,6 @@ public class RandomGenerator implements Serializable {
         if (seedString != null && !seedString.isEmpty()) {
             requestedSeed = Long.parseLong(seedString);
         }
-        Random random;
         if (requestedSeed != 0) {
             random = new Random();
             random.setSeed(requestedSeed);

--- a/src/main/java/com/alphatica/genotick/genotick/RandomGenerator.java
+++ b/src/main/java/com/alphatica/genotick/genotick/RandomGenerator.java
@@ -8,8 +8,8 @@ public class RandomGenerator implements Serializable {
 
     private static final long serialVersionUID = -32164662984L;
 
-    Random random;
-    long seed;
+    private Random random;
+    private long seed;
     
     private RandomGenerator(long requestedSeed) {
         String seedString = System.getenv("GENOTICK_RANDOM_SEED");

--- a/src/main/java/com/alphatica/genotick/genotick/RandomGenerator.java
+++ b/src/main/java/com/alphatica/genotick/genotick/RandomGenerator.java
@@ -5,7 +5,6 @@ import java.util.Random;
 
 public class RandomGenerator {
 
-    private static long SEED = 0;
     private RandomGenerator() {}
 
     public static Random create(long seed) {
@@ -13,19 +12,13 @@ public class RandomGenerator {
         if (seedString != null && !seedString.isEmpty()) {
             seed = Long.parseLong(seedString);
         }
-        SEED = seed;
-        Random random = 0 != SEED ? new Random() : ThreadLocalRandom.current();
+        Random random;
         if (seed != 0) {
+            random = new Random();
             random.setSeed(seed);
+        } else {
+            random = ThreadLocalRandom.current();
         }
         return random;
-    }
-    
-    public static Random get() {
-	    return create(SEED);
-    }
-    
-    public static long getSeed() {
-	  		return SEED;
     }
 }

--- a/src/main/java/com/alphatica/genotick/genotick/RandomGenerator.java
+++ b/src/main/java/com/alphatica/genotick/genotick/RandomGenerator.java
@@ -1,9 +1,11 @@
 package com.alphatica.genotick.genotick;
 
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.Random;
 
 public class RandomGenerator {
 
+    private static long SEED = 0;
     private RandomGenerator() {}
 
     public static Random create(long seed) {
@@ -11,10 +13,19 @@ public class RandomGenerator {
         if (seedString != null && !seedString.isEmpty()) {
             seed = Long.parseLong(seedString);
         }
-        Random random = new Random();
+        SEED = seed;
+        Random random = 0 != SEED ? new Random() : ThreadLocalRandom.current();
         if (seed != 0) {
             random.setSeed(seed);
         }
         return random;
+    }
+    
+    public static Random get() {
+	    return create(SEED);
+    }
+    
+    public static long getSeed() {
+	  		return SEED;
     }
 }

--- a/src/main/java/com/alphatica/genotick/genotick/Simulation.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Simulation.java
@@ -35,7 +35,6 @@ public class Simulation {
 
     public void start(MainSettings mainSettings, MainAppData data, MainInterface.SessionResult sessionResult) throws IllegalAccessException {
         TimeCounter simulationRunTime = new TimeCounter("Simulation Run Time", false);
-
         if(validateSettings(mainSettings)) {
             logSettings(mainSettings);
             RobotKiller killer = createRobotKiller(mainSettings);
@@ -45,7 +44,6 @@ public class Simulation {
             Engine engine = createEngine(mainSettings, data, killer, breeder, population, sessionResult);
             engine.start();
         }
-
         System.out.println(format("Simulation finished in %d seconds", simulationRunTime.stop(TimeUnit.SECONDS)));
     }
 

--- a/src/main/java/com/alphatica/genotick/genotick/Simulation.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Simulation.java
@@ -19,6 +19,10 @@ import com.alphatica.genotick.processor.RobotExecutorFactory;
 import com.alphatica.genotick.timepoint.TimePointExecutor;
 import com.alphatica.genotick.timepoint.TimePointExecutorFactory;
 import com.alphatica.genotick.ui.UserOutput;
+import com.alphatica.genotick.utility.TimeCounter;
+
+import static java.lang.String.format;
+import java.util.concurrent.TimeUnit;
 
 public class Simulation {
 
@@ -30,6 +34,8 @@ public class Simulation {
     }
 
     public void start(MainSettings mainSettings, MainAppData data, MainInterface.SessionResult sessionResult) throws IllegalAccessException {
+        TimeCounter simulationRunTime = new TimeCounter("Simulation Run Time", false);
+
         if(validateSettings(mainSettings)) {
             logSettings(mainSettings);
             RobotKiller killer = createRobotKiller(mainSettings);
@@ -39,6 +45,8 @@ public class Simulation {
             Engine engine = createEngine(mainSettings, data, killer, breeder, population, sessionResult);
             engine.start();
         }
+
+        System.out.println(format("Simulation finished in %d seconds", simulationRunTime.stop(TimeUnit.SECONDS)));
     }
 
     private boolean validateSettings(MainSettings settings) {

--- a/src/main/java/com/alphatica/genotick/instructions/InstructionList.java
+++ b/src/main/java/com/alphatica/genotick/instructions/InstructionList.java
@@ -1,26 +1,27 @@
 package com.alphatica.genotick.instructions;
 
+import com.alphatica.genotick.genotick.RandomGenerator;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 public class InstructionList implements Serializable {
 
     private static final long serialVersionUID = 267402795981161615L;
 
-    private final Random random;
+    private final RandomGenerator random;
     private final List<Instruction> list;
     private final double[] variables;
 
-    private InstructionList(Random random) {
+    private InstructionList(RandomGenerator random) {
         this.random = random;
         this.list = new ArrayList<>();
         int variablesCount = 1 + Math.abs(random.nextInt() % 1024);
         this.variables = new double[variablesCount];
     }
 
-    public static InstructionList create(Random random) {
+    public static InstructionList create(RandomGenerator random) {
         return new InstructionList(random);
     }
 

--- a/src/main/java/com/alphatica/genotick/instructions/InstructionList.java
+++ b/src/main/java/com/alphatica/genotick/instructions/InstructionList.java
@@ -63,8 +63,11 @@ public class InstructionList implements Serializable {
     }
 
     private int validateVariableNumber(int index) {
-				if(index < 0 || index >= variables.length) return Math.abs(index % variables.length);
-	    	return index;       
+    	if(index < 0 || index >= variables.length) {
+        	return Math.abs(index % variables.length);
+        } else {
+        	return index;       
+        }
     }
 
     private int fixPosition(int position) {

--- a/src/main/java/com/alphatica/genotick/instructions/InstructionList.java
+++ b/src/main/java/com/alphatica/genotick/instructions/InstructionList.java
@@ -63,7 +63,8 @@ public class InstructionList implements Serializable {
     }
 
     private int validateVariableNumber(int index) {
-        return Math.abs(index % variables.length);
+				if(index < 0 || index >= variables.length) return Math.abs(index % variables.length);
+	    	return index;       
     }
 
     private int fixPosition(int position) {

--- a/src/main/java/com/alphatica/genotick/killer/SimpleRobotKiller.java
+++ b/src/main/java/com/alphatica/genotick/killer/SimpleRobotKiller.java
@@ -3,7 +3,6 @@ package com.alphatica.genotick.killer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 
 import com.alphatica.genotick.genotick.RandomGenerator;
 import com.alphatica.genotick.population.Population;
@@ -12,7 +11,7 @@ import com.alphatica.genotick.ui.UserOutput;
 
 class SimpleRobotKiller implements RobotKiller {
     private RobotKillerSettings settings;
-    private Random random;
+    private RandomGenerator random;
     private final UserOutput output;
 
     private SimpleRobotKiller(UserOutput output) {

--- a/src/main/java/com/alphatica/genotick/mutator/SimpleMutator.java
+++ b/src/main/java/com/alphatica/genotick/mutator/SimpleMutator.java
@@ -7,11 +7,10 @@ import com.alphatica.genotick.processor.Processor;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 class SimpleMutator implements Mutator {
     private MutatorSettings settings;
-    private Random random;
+    private RandomGenerator random;
     private final List<Class< ? super Instruction>> instructionList;
     private int totalInstructions;
 

--- a/src/main/java/com/alphatica/genotick/population/PopulationDAOFactory.java
+++ b/src/main/java/com/alphatica/genotick/population/PopulationDAOFactory.java
@@ -1,18 +1,16 @@
 package com.alphatica.genotick.population;
 
-import java.util.Random;
-
 import com.alphatica.genotick.genotick.RandomGenerator;
 
 public class PopulationDAOFactory {    
     
     public static PopulationDAO getDefaultDAO(PopulationSettings settings) {
         if (settings.daoOption.contains(PopulationDaoOption.RAM)) {
-            Random random = RandomGenerator.create(settings.randomSeed);
+            RandomGenerator random = RandomGenerator.create(settings.randomSeed);
             return new PopulationDAORAM(random);
         }
         else if (settings.daoOption.contains(PopulationDaoOption.DISK)) {
-            Random random = RandomGenerator.create(settings.randomSeed);
+            RandomGenerator random = RandomGenerator.create(settings.randomSeed);
             return new PopulationDAOFileSystem(random, settings.daoPath);
         }
         else {

--- a/src/main/java/com/alphatica/genotick/population/PopulationDAOFileSystem.java
+++ b/src/main/java/com/alphatica/genotick/population/PopulationDAOFileSystem.java
@@ -17,6 +17,8 @@ import java.util.stream.Stream;
 
 import static java.lang.String.format;
 
+import com.alphatica.genotick.genotick.RandomGenerator;
+
 public class PopulationDAOFileSystem implements PopulationDAO {
     private static final String FILE_EXTENSION = ".prg";
     private final String robotsPath;
@@ -24,7 +26,7 @@ public class PopulationDAOFileSystem implements PopulationDAO {
     private final List<RobotName> names;
 
     public PopulationDAOFileSystem(String path) {
-        this(new Random(), path);
+        this(RandomGenerator.get(), path);
     }
     
     public PopulationDAOFileSystem(Random random, String path) {
@@ -58,13 +60,19 @@ public class PopulationDAOFileSystem implements PopulationDAO {
     @Override
     public void saveRobot(Robot robot) {
         if(robot.getName() == null) {
+	        synchronized(this) {
             RobotName name = getAvailableName();
             robot.setName(name);
             names.add(name);
-        }
-        File file = createFileForName(robot.getName());
-        saveRobotToFile(robot,file);
-    }
+            
+		        File file = createFileForName(robot.getName());
+		        saveRobotToFile(robot,file);
+        	}
+        } else {
+        		File file = createFileForName(robot.getName());
+						saveRobotToFile(robot,file);
+   			}
+   }
 
     @Override
     public void removeRobot(RobotName robotName) {

--- a/src/main/java/com/alphatica/genotick/population/PopulationDAOFileSystem.java
+++ b/src/main/java/com/alphatica/genotick/population/PopulationDAOFileSystem.java
@@ -11,7 +11,6 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -22,14 +21,14 @@ import com.alphatica.genotick.genotick.RandomGenerator;
 public class PopulationDAOFileSystem implements PopulationDAO {
     private static final String FILE_EXTENSION = ".prg";
     private final String robotsPath;
-    private final Random random;
+    private final RandomGenerator random;
     private final List<RobotName> names;
 
     public PopulationDAOFileSystem(String path) {
         this(RandomGenerator.create(0), path);
     }
     
-    public PopulationDAOFileSystem(Random random, String path) {
+    public PopulationDAOFileSystem(RandomGenerator random, String path) {
         checkPath(path);
         this.robotsPath = path;
         this.names = loadRobotNames();
@@ -60,18 +59,15 @@ public class PopulationDAOFileSystem implements PopulationDAO {
     @Override
     public void saveRobot(Robot robot) {
         if(robot.getName() == null) {
-	        synchronized(this) {
+            synchronized(this) {
                 RobotName name = getAvailableName();
                 robot.setName(name);
                 names.add(name);
-                
-    	        File file = createFileForName(robot.getName());
-    	        saveRobotToFile(robot,file);
-        	}
+                saveRobotToFile(robot);
+            }
         } else {
-            File file = createFileForName(robot.getName());
-            saveRobotToFile(robot,file);
-		}
+            saveRobotToFile(robot);
+        }
    }
 
     @Override
@@ -151,7 +147,8 @@ public class PopulationDAOFileSystem implements PopulationDAO {
         return new File(robotsPath + File.separator + name.toString() + FILE_EXTENSION);
     }
 
-    private void saveRobotToFile(Robot robot, File file)  {
+    private void saveRobotToFile(Robot robot)  {
+        File file = createFileForName(robot.getName());
         deleteFileIfExists(file);
         try(ObjectOutputStream ous = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(file)))) {
             ous.writeObject(robot);

--- a/src/main/java/com/alphatica/genotick/population/PopulationDAOFileSystem.java
+++ b/src/main/java/com/alphatica/genotick/population/PopulationDAOFileSystem.java
@@ -26,7 +26,7 @@ public class PopulationDAOFileSystem implements PopulationDAO {
     private final List<RobotName> names;
 
     public PopulationDAOFileSystem(String path) {
-        this(RandomGenerator.get(), path);
+        this(RandomGenerator.create(0), path);
     }
     
     public PopulationDAOFileSystem(Random random, String path) {
@@ -61,17 +61,17 @@ public class PopulationDAOFileSystem implements PopulationDAO {
     public void saveRobot(Robot robot) {
         if(robot.getName() == null) {
 	        synchronized(this) {
-            RobotName name = getAvailableName();
-            robot.setName(name);
-            names.add(name);
-            
-		        File file = createFileForName(robot.getName());
-		        saveRobotToFile(robot,file);
+                RobotName name = getAvailableName();
+                robot.setName(name);
+                names.add(name);
+                
+    	        File file = createFileForName(robot.getName());
+    	        saveRobotToFile(robot,file);
         	}
         } else {
-        		File file = createFileForName(robot.getName());
-						saveRobotToFile(robot,file);
-   			}
+            File file = createFileForName(robot.getName());
+            saveRobotToFile(robot,file);
+		}
    }
 
     @Override

--- a/src/main/java/com/alphatica/genotick/population/PopulationDAORAM.java
+++ b/src/main/java/com/alphatica/genotick/population/PopulationDAORAM.java
@@ -36,7 +36,7 @@ public class PopulationDAORAM implements PopulationDAO {
     }
 
     @Override
-    public void saveRobot(Robot robot) {
+    public synchronized void saveRobot(Robot robot) {
         if(robot.getName() == null) {
             robot.setName(getAvailableRobotName());
         }

--- a/src/main/java/com/alphatica/genotick/population/PopulationDAORAM.java
+++ b/src/main/java/com/alphatica/genotick/population/PopulationDAORAM.java
@@ -1,16 +1,17 @@
 package com.alphatica.genotick.population;
 
+import com.alphatica.genotick.genotick.RandomGenerator;
+
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 import java.util.stream.Stream;
 
 public class PopulationDAORAM implements PopulationDAO {
 
     private final Map<RobotName,Robot> map;
-    private final Random random;
+    private final RandomGenerator random;
 
-    public PopulationDAORAM(Random random) {
+    public PopulationDAORAM(RandomGenerator random) {
         this.map = new HashMap<>();
         this.random = random;
     }

--- a/src/main/java/com/alphatica/genotick/population/Robot.java
+++ b/src/main/java/com/alphatica/genotick/population/Robot.java
@@ -4,6 +4,7 @@ package com.alphatica.genotick.population;
 import com.alphatica.genotick.data.DataSetName;
 import com.alphatica.genotick.genotick.Outcome;
 import com.alphatica.genotick.genotick.Prediction;
+import com.alphatica.genotick.genotick.RandomGenerator;
 import com.alphatica.genotick.genotick.RobotData;
 import com.alphatica.genotick.genotick.RobotDataPair;
 import com.alphatica.genotick.genotick.RobotResult;
@@ -17,7 +18,6 @@ import java.lang.reflect.Modifier;
 import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 
 import static java.util.Optional.ofNullable;
 
@@ -43,7 +43,7 @@ public class Robot implements Serializable {
     private final Map<DataSetName, Prediction> current = new HashMap<>();
     private final Map<DataSetName, Prediction> pending = new HashMap<>();
 
-    public static Robot createEmptyRobot(RobotSettings settings, Random random) {
+    public static Robot createEmptyRobot(RobotSettings settings, RandomGenerator random) {
         return new Robot(settings, random);
     }
 
@@ -201,7 +201,7 @@ public class Robot implements Serializable {
         return bias;
     }
 
-    private Robot(RobotSettings settings, Random random) {
+    private Robot(RobotSettings settings, RandomGenerator random) {
         this.settings = settings;
         this.mainFunction = InstructionList.create(random);
     }

--- a/src/main/java/com/alphatica/genotick/ui/RandomParametersInput.java
+++ b/src/main/java/com/alphatica/genotick/ui/RandomParametersInput.java
@@ -8,11 +8,9 @@ import com.alphatica.genotick.timepoint.TimePoint;
 import com.alphatica.genotick.breeder.InheritedWeightMode;
 import com.alphatica.genotick.chart.GenoChartMode;
 
-import java.util.Random;
-
 class RandomParametersInput extends BasicUserInput {
 
-    private Random random;
+    private RandomGenerator random;
     
     RandomParametersInput(UserOutput output) {
         super(output);

--- a/src/main/java/com/alphatica/genotick/utility/ParallelTasks.java
+++ b/src/main/java/com/alphatica/genotick/utility/ParallelTasks.java
@@ -1,0 +1,26 @@
+package com.alphatica.genotick.utility;
+
+import java.util.function.Consumer;
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+public class ParallelTasks {
+
+    private ParallelTasks() {}
+
+    public static void prepareDefaultThreadPool() {
+    	int poolCores = Math.max(Runtime.getRuntime().availableProcessors()*2, 2);
+    	System.setProperty("java.util.concurrent.ForkJoinPool.common.parallelism", Integer.toString(poolCores));
+    }
+    
+    public static void parallelNumberedTask(int count, Consumer<Integer> action) {
+        Objects.requireNonNull(action);
+        int cores =  Math.max(2, Runtime.getRuntime().availableProcessors());
+        int taskSize = (int)Math.ceil((double)count / (double)cores);
+        IntStream.range(0, count)
+            .filter(blockIndex -> blockIndex % taskSize == 0)
+            .parallel()
+            .forEach(blockIndex -> action.accept(Math.min(taskSize, count-blockIndex)));
+    }
+}
+

--- a/src/main/java/com/alphatica/genotick/utility/TimeCounter.java
+++ b/src/main/java/com/alphatica/genotick/utility/TimeCounter.java
@@ -1,6 +1,7 @@
 package com.alphatica.genotick.utility;
 
 import static java.lang.String.format;
+import java.util.concurrent.TimeUnit;
 
 public class TimeCounter {
     
@@ -29,12 +30,16 @@ public class TimeCounter {
     }
     
     public long stop() {
+        return stop(TimeUnit.NANOSECONDS);
+    }
+    
+    public long stop(TimeUnit timeUnit) {
         stopNanoSeconds = System.nanoTime();
         final long elapsedNanoSeconds = getElapsedNanoSeconds();
         if (printOnStop) {
             print(elapsedNanoSeconds, 2);
         }
-        return elapsedNanoSeconds;
+        return timeUnit.convert(elapsedNanoSeconds, TimeUnit.NANOSECONDS);
     }
     
     public long getElapsedNanoSeconds() {


### PR DESCRIPTION
so that the pipeline does not stall waiting for the main thread to create new robots to execute.  Minor locking changes included which are required since creation will run on worker threads.  Fixed random generator to use threadlocalrandom when possible.  Heavy contention occurs without this.  InstructionList also has minor code fix to avoid the use of % when possible (performance fix)