### PR TITLE
Population merging support.

### DIFF
--- a/src/main/java/com/alphatica/genotick/breeder/SimpleBreeder.java
+++ b/src/main/java/com/alphatica/genotick/breeder/SimpleBreeder.java
@@ -11,18 +11,18 @@ import com.alphatica.genotick.population.Robot;
 import com.alphatica.genotick.population.RobotInfo;
 import com.alphatica.genotick.population.RobotSettings;
 import com.alphatica.genotick.ui.UserOutput;
+import com.alphatica.genotick.utility.ParallelTasks;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 
 import static com.alphatica.genotick.utility.Assert.gassert;
 
 public class SimpleBreeder implements RobotBreeder {
     private BreederSettings settings;
     private Mutator mutator;
-    private Random random;
+    private RandomGenerator random;
     private final WeightCalculator weightCalculator;
     private final UserOutput output;
 
@@ -68,10 +68,19 @@ public class SimpleBreeder implements RobotBreeder {
         }
     }
 
-    private void fillWithRobots(int count, Population population) {
+    private void fillWithRobotsSync(int count, Population population) {
         for (int i = 0; i < count; i++) {
             createNewRobot(population);
         }
+    }
+
+    private void fillWithRobots(int count, Population population) {
+    	if(count < 32 || random.getSeed() != 0) {
+            fillWithRobotsSync(count, population);
+            return;
+    	} else {
+            ParallelTasks.parallelNumberedTask(count, (subCount) -> fillWithRobotsSync(subCount, population));
+    	} 
     }
 
     private void createNewRobot(Population population) {

--- a/src/main/java/com/alphatica/genotick/data/Column.java
+++ b/src/main/java/com/alphatica/genotick/data/Column.java
@@ -16,7 +16,8 @@ public class Column {
         OPEN   = 0,
         HIGH   = 1,
         LOW    = 2,
-        CLOSE  = 3;
+        CLOSE  = 3,
+        OTHER  = 4;
     }
 
     public static class Names {
@@ -34,6 +35,7 @@ public class Column {
                 "high",
                 "low",
                 "close",
+                "other",
         };
     }
     

--- a/src/main/java/com/alphatica/genotick/data/DataSeries.java
+++ b/src/main/java/com/alphatica/genotick/data/DataSeries.java
@@ -59,6 +59,10 @@ public class DataSeries {
         return data.length;
     }
     
+    public int optionalColumnCount() {
+        return data.length - Column.OHLC.OTHER;
+    }
+    
     public int barCount() {
         return data.length > 0 ? data[0].length : 0;
     }

--- a/src/main/java/com/alphatica/genotick/genotick/ErrorCode.java
+++ b/src/main/java/com/alphatica/genotick/genotick/ErrorCode.java
@@ -1,6 +1,5 @@
 package com.alphatica.genotick.genotick;
 
-
 enum ErrorCode {
     NO_ERROR(0),
     NO_INPUT(1),

--- a/src/main/java/com/alphatica/genotick/genotick/ErrorCode.java
+++ b/src/main/java/com/alphatica/genotick/genotick/ErrorCode.java
@@ -8,7 +8,8 @@ enum ErrorCode {
     UNKNOWN_ARGUMENT(3),
     INVALID_SESSION(4),
     DUPLICATE_SESSION(5),
-    INSUFFICIENT_DATA(6);
+    INSUFFICIENT_DATA(6),
+    MISSING_ARGUMENT(7);
 
     private final int code;
 

--- a/src/main/java/com/alphatica/genotick/genotick/Main.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Main.java
@@ -13,10 +13,6 @@ import com.alphatica.genotick.data.FileSystemDataLoader;
 import com.alphatica.genotick.data.FileSystemDataSaver;
 import com.alphatica.genotick.data.MainAppData;
 import com.alphatica.genotick.data.YahooFixer;
-import com.alphatica.genotick.population.Population;
-import com.alphatica.genotick.population.PopulationDAOFileSystem;
-import com.alphatica.genotick.population.Robot;
-import com.alphatica.genotick.population.RobotInfo;
 import com.alphatica.genotick.reversal.Reversal;
 import com.alphatica.genotick.ui.Parameters;
 import com.alphatica.genotick.ui.UserInput;
@@ -26,8 +22,6 @@ import com.alphatica.genotick.utility.TimeCounter;
 import com.alphatica.genotick.utility.ParallelTasks;
 
 import java.io.IOException;
-import java.util.Collection;
-
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/com/alphatica/genotick/genotick/Main.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Main.java
@@ -18,8 +18,11 @@ import com.alphatica.genotick.ui.Parameters;
 import com.alphatica.genotick.ui.UserInput;
 import com.alphatica.genotick.ui.UserInputOutputFactory;
 import com.alphatica.genotick.ui.UserOutput;
+import com.alphatica.genotick.utility.TimeCounter;
+import com.alphatica.genotick.utility.ParallelTasks;
 
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 import java.io.IOException;
 
 import static java.lang.String.format;
@@ -39,6 +42,8 @@ public class Main {
     }
 
     public ErrorCode init(String[] args, MainInterface.Session session) throws IOException, IllegalAccessException {
+        ParallelTasks.prepareDefaultThreadPool();
+        TimeCounter totalRunTime = new TimeCounter("Total Run Time", false);
         this.session = session;
         Parameters parameters = new Parameters(args);
         if (canContinue) {
@@ -68,17 +73,17 @@ public class Main {
         if (canContinue) {
             initSimulation(parameters);
         }
-        printError(error);
+        printError(error, totalRunTime.stop(TimeUnit.SECONDS));
         return error;
     }
-
+    
     private void setError(ErrorCode error) {
         this.error = error;
         this.canContinue = false;
     }
 
-    private void printError(final ErrorCode error) {
-        System.out.println(format("Program finished with error code %s(%d)", error.toString(), error.getValue()));
+    private void printError(final ErrorCode error, long elapsedSeconds) {
+        System.out.println(format("Program finished with error code %s(%d) in %d seconds", error.toString(), error.getValue(), elapsedSeconds));
     }
 
     private void initHelp(Parameters parameters) {

--- a/src/main/java/com/alphatica/genotick/genotick/Main.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Main.java
@@ -213,10 +213,6 @@ public class Main {
         }
     }
 
-<<<<<<< HEAD
-=======
-
->>>>>>> 0155b1c560c55c71c482adb3c29f62320df77bc6
     private void initYahoo(Parameters parameters) {
         String path = parameters.getValue("fixYahoo");
         if(path != null) {

--- a/src/main/java/com/alphatica/genotick/genotick/Main.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Main.java
@@ -13,6 +13,10 @@ import com.alphatica.genotick.data.FileSystemDataLoader;
 import com.alphatica.genotick.data.FileSystemDataSaver;
 import com.alphatica.genotick.data.MainAppData;
 import com.alphatica.genotick.data.YahooFixer;
+import com.alphatica.genotick.population.Population;
+import com.alphatica.genotick.population.PopulationDAOFileSystem;
+import com.alphatica.genotick.population.Robot;
+import com.alphatica.genotick.population.RobotInfo;
 import com.alphatica.genotick.reversal.Reversal;
 import com.alphatica.genotick.ui.Parameters;
 import com.alphatica.genotick.ui.UserInput;
@@ -21,9 +25,9 @@ import com.alphatica.genotick.ui.UserOutput;
 import com.alphatica.genotick.utility.TimeCounter;
 import com.alphatica.genotick.utility.ParallelTasks;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
-import java.io.IOException;
 
 import static java.lang.String.format;
 
@@ -65,6 +69,9 @@ public class Main {
             initShowRobot(parameters);
         }
         if (canContinue) {
+            initMerge(parameters);
+        }
+        if (canContinue) {
             initReverse(parameters);
         }
         if (canContinue) {
@@ -104,6 +111,8 @@ public class Main {
             System.out.println("    java -jar genotick.jar showPopulation=directory_with_population");
             System.out.print("Show robot info: ");
             System.out.println("    java -jar genotick.jar showRobot=directory_with_population\\system name.prg");
+            System.out.print("Merge robots: ");
+            System.out.println("    java -jar genotick.jar mergeRobots=directory_for_merged_robots candidateRobots=base_directory_of_Population_folders");
             System.out.print("Draw price curves for asset data ");
             System.out.println("    java -jar genotick.jar drawData=mydata");
             System.out.println("contact:        lukasz.wojtow@gmail.com");
@@ -178,6 +187,27 @@ public class Main {
                 System.err.println(e.getMessage());
             }
             setError(ErrorCode.NO_ERROR);
+        }
+    }
+
+    private void initMerge(Parameters parameters) {
+        String destination = parameters.getValue("mergeRobots");
+        if(destination != null) {
+            String source = parameters.getValue("candidateRobots");
+            if(source != null) {
+                ErrorCode errorCode = ErrorCode.NO_OUTPUT;
+                try {
+                    errorCode = Merge.mergePopulations(destination, source);
+                } catch (IllegalAccessException e) {
+                    e.printStackTrace();
+                    output.errorMessage(e.getMessage());
+                }
+                setError(errorCode);
+            } else {
+                output.errorMessage("mergeRobots command found but candidateRobots argument is missing.");
+                setError(ErrorCode.MISSING_ARGUMENT);
+                return;
+            }
         }
     }
 

--- a/src/main/java/com/alphatica/genotick/genotick/Main.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Main.java
@@ -26,6 +26,7 @@ import com.alphatica.genotick.utility.TimeCounter;
 import com.alphatica.genotick.utility.ParallelTasks;
 
 import java.io.IOException;
+
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/com/alphatica/genotick/genotick/Merge.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Merge.java
@@ -31,7 +31,7 @@ class Merge {
                 .parallelStream()
                 .forEach(directory -> mergeSource(destinationPopulation, destinationPath.getAbsolutePath(), directory));
         } catch (IOException e) {
-            //
+            // Falling thruogh here just ignores folders with any access errors.
         }
         destinationPopulation.saveOnDisk();
         double newScore = populationScore(destinationPopulation);

--- a/src/main/java/com/alphatica/genotick/genotick/Merge.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Merge.java
@@ -1,0 +1,145 @@
+package com.alphatica.genotick.genotick;
+
+import com.alphatica.genotick.population.Population;
+import com.alphatica.genotick.population.PopulationDAOFileSystem;
+import com.alphatica.genotick.population.Robot;
+import com.alphatica.genotick.population.RobotInfo;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+class Merge {
+    private Merge() {}
+    
+    public static ErrorCode mergePopulation(String destination, String source) throws IllegalAccessException {
+        File destinationPath = new File(destination);
+        destinationPath.mkdirs();
+        PopulationDAOFileSystem dao = new PopulationDAOFileSystem(destinationPath.getAbsolutePath());
+        Population destinationPopulation = PopulationFactory.getDefaultPopulation(dao);
+        double initialScore = populationScore(destinationPopulation);
+        System.out.println(format("Current population size: %d desiredSize: %d population score: %.4f", 
+            destinationPopulation.getSize(), destinationPopulation.getDesiredSize(), initialScore));
+        try {
+            System.out.println(destinationPath.getAbsolutePath());
+            Files.walk(Paths.get(source), 1)
+                .filter(path -> Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS))
+                .collect(Collectors.toList())
+                .parallelStream()
+                .forEach(directory -> mergeSource(destinationPopulation, destinationPath.getAbsolutePath(), directory));
+        } catch (IOException e) {
+            //
+        }
+        destinationPopulation.saveOnDisk();
+        double newScore = populationScore(destinationPopulation);
+        if(newScore > initialScore) {
+            System.out.println(format("Success merging populations. New size: %d old score: %.4f new score: %.4f", 
+                destinationPopulation.getSize(), initialScore, newScore));
+            return ErrorCode.NO_ERROR;
+        }
+        if(newScore < initialScore) {
+            System.out.println(format("Warning population score decreased after merge:%.4f", newScore));
+        }
+        return ErrorCode.NO_OUTPUT;
+    }
+    
+    private static void mergeSource(Population destinationPopulation, String destination, Path sourcePath) {
+        String source = sourcePath.toString().replace("./", "");
+        File sourceFile = new File(source);
+        source = sourceFile.getAbsolutePath();
+        if(destination.compareTo(source) == 0) {
+            return;
+        }
+        PopulationDAOFileSystem daoSource = new PopulationDAOFileSystem(source);
+        Population sourcePopulation = PopulationFactory.getDefaultPopulation(daoSource);
+        if(sourcePopulation.getSize() < 1) {
+            return;
+        }
+        System.out.println(source);
+        sourcePopulation.getRobotInfoList()
+            .stream()
+            .filter(robot -> robot.getWeight() == 0.0)
+            .collect(Collectors.toList())
+            .forEach(robot -> sourcePopulation.removeRobot(robot.getName()));
+        
+        while(sourcePopulation.getSize() > 0) {
+            RobotInfo best = findBestPerformingRobot(sourcePopulation);
+            if(best == null) {
+                break;
+            }
+            
+            synchronized(destinationPopulation) {
+                RobotInfo worst = findWorstPerformingRobot(destinationPopulation);
+                
+                if(destinationPopulation.getSize() < destinationPopulation.getDesiredSize() 
+                    && Math.abs(best.getWeight()) > 0.0 
+                    && best.isPredicting()) {
+                    // Take robot...
+                    System.out.println(format("Adding robot %s to destination due to desination not full. Weight: %.4f new size: %d", 
+                        best.getName(), best.getWeight(), destinationPopulation.getSize()+1));
+                    if(moveRobot(sourcePopulation, destinationPopulation, best)) {
+                        continue;
+                    }
+                } else if(worst != null 
+                    && Math.abs(best.getWeight()) > 0 
+                    && Math.abs(worst.getWeight()) < Math.abs(best.getWeight()) 
+                    && (best.isPredicting() || !worst.isPredicting())) {
+                    System.out.println(format("Adding robot %s to destination due to higher weight. Weight: %.4f population score: %.4f", 
+                        best.getName(), best.getWeight(), populationScore(destinationPopulation)));
+                    destinationPopulation.removeRobot(worst.getName());
+                    if(moveRobot(sourcePopulation, destinationPopulation, best)) {
+                        continue;
+                    }
+                }
+            }
+            break;
+        }
+        try {
+            Files.walk(sourceFile.toPath())
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
+        } catch (IOException e) {
+            System.out.println(format("Exception clearing directory %s. Exception %s", sourceFile, e.toString()));
+        }
+    }
+    
+    private static double populationScore(Population population) {
+        return population.getRobotInfoList().stream().mapToDouble((robot) -> {
+            return Math.abs(robot.getWeight());
+        }).average().orElse(0);
+    }
+    
+    private static boolean moveRobot(Population sourcePopulation, Population destinationPopulation, RobotInfo robot) {
+        Robot movingRobot = sourcePopulation.getRobot(robot.getName());
+        if(movingRobot == null) {
+            return false;
+        }
+        sourcePopulation.removeRobot(robot.getName());
+        movingRobot.setName(null);
+        destinationPopulation.saveRobot(movingRobot);
+        return true;
+    }
+    
+    private static RobotInfo findWorstPerformingRobot(Population population) {
+        if(population.getRobotInfoList().size() < 1) {
+            return null;
+        }
+        return population.getRobotInfoList().stream().min((a,b) -> {
+            return (int)(Math.abs(a.getWeight()) - Math.abs(b.getWeight()));
+        }).get();
+    }
+    
+    private static RobotInfo findBestPerformingRobot(Population population) {
+        if(population.getRobotInfoList().size() < 1) {
+            return null;
+        }
+        return population.getRobotInfoList().stream().max((a,b) -> {
+            return (int)(Math.abs(a.getWeight()) - Math.abs(b.getWeight()));
+        }).get();
+    }
+}
+

--- a/src/main/java/com/alphatica/genotick/genotick/Merge.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Merge.java
@@ -50,7 +50,7 @@ class Merge {
         String source = sourcePath.toString().replace("./", "");
         File sourceFile = new File(source);
         source = sourceFile.getAbsolutePath();
-        if(destination.compareTo(source) == 0) {
+        if(destination.equals(source)) {
             return;
         }
         PopulationDAOFileSystem daoSource = new PopulationDAOFileSystem(source);
@@ -125,7 +125,7 @@ class Merge {
     }
     
     private static RobotInfo findWorstPerformingRobot(Population population) {
-        if(population.getRobotInfoList().size() < 1) {
+        if(population.getRobotInfoList().isEmpty()) {
             return null;
         }
         return population.getRobotInfoList().stream().min((a,b) -> {
@@ -134,7 +134,7 @@ class Merge {
     }
     
     private static RobotInfo findBestPerformingRobot(Population population) {
-        if(population.getRobotInfoList().size() < 1) {
+        if(population.getRobotInfoList().isEmpty()) {
             return null;
         }
         return population.getRobotInfoList().stream().max((a,b) -> {

--- a/src/main/java/com/alphatica/genotick/genotick/Merge.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Merge.java
@@ -15,7 +15,7 @@ import static java.lang.String.format;
 class Merge {
     private Merge() {}
     
-    public static ErrorCode mergePopulation(String destination, String source) throws IllegalAccessException {
+    public static ErrorCode mergePopulations(String destination, String source) throws IllegalAccessException {
         File destinationPath = new File(destination);
         destinationPath.mkdirs();
         PopulationDAOFileSystem dao = new PopulationDAOFileSystem(destinationPath.getAbsolutePath());

--- a/src/main/java/com/alphatica/genotick/genotick/RandomGenerator.java
+++ b/src/main/java/com/alphatica/genotick/genotick/RandomGenerator.java
@@ -1,20 +1,75 @@
 package com.alphatica.genotick.genotick;
 
+import java.io.Serializable;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.Random;
 
-public class RandomGenerator {
+public class RandomGenerator implements Serializable {
 
-    private RandomGenerator() {}
+    private static final long serialVersionUID = -32164662984L;
 
-    public static Random create(long seed) {
+    private Random random;
+    private long seed;
+    
+    private RandomGenerator(long requestedSeed) {
         String seedString = System.getenv("GENOTICK_RANDOM_SEED");
         if (seedString != null && !seedString.isEmpty()) {
-            seed = Long.parseLong(seedString);
+            requestedSeed = Long.parseLong(seedString);
         }
-        Random random = new Random();
-        if (seed != 0) {
-            random.setSeed(seed);
+        if (requestedSeed != 0) {
+            random = new Random();
+            random.setSeed(requestedSeed);
+        } else {
+            random = null;
         }
-        return random;
+        seed = requestedSeed;
+    }
+    
+    public long getSeed() {
+        return seed;
+    }
+
+    public static RandomGenerator create(long requestedSeed) {
+        return new RandomGenerator(requestedSeed);
+    }
+    
+    public int nextInt() {
+        if(random != null) {
+            return random.nextInt();
+        } else {
+            return ThreadLocalRandom.current().nextInt();
+        }
+    }
+    
+    public int nextInt(int bound) {
+        if(random != null) {
+            return random.nextInt(bound);
+        } else {
+            return ThreadLocalRandom.current().nextInt(bound);
+        }
+    }
+
+    public long nextLong() {
+        if(random != null) {
+            return random.nextLong();
+        } else {
+            return ThreadLocalRandom.current().nextLong();
+        }
+    }
+
+    public double nextDouble() {
+        if(random != null) {
+            return random.nextDouble();
+        } else {
+            return ThreadLocalRandom.current().nextDouble();
+        }
+    }
+    
+    public boolean nextBoolean() {
+        if(random != null) {
+            return random.nextBoolean();
+        } else {
+            return ThreadLocalRandom.current().nextBoolean();
+        }
     }
 }

--- a/src/main/java/com/alphatica/genotick/genotick/RobotData.java
+++ b/src/main/java/com/alphatica/genotick/genotick/RobotData.java
@@ -28,6 +28,10 @@ public class RobotData {
     public int getColumnCount() {
         return ohlcLookbackData.columnCount();
     }
+    
+    public int getOptionalColumnCount() {
+        return ohlcLookbackData.optionalColumnCount();
+    }
 
     double getLastPriceOpen() {
         return ohlcLookbackData.get(Column.OHLC.OPEN, 0);

--- a/src/main/java/com/alphatica/genotick/genotick/Simulation.java
+++ b/src/main/java/com/alphatica/genotick/genotick/Simulation.java
@@ -19,6 +19,10 @@ import com.alphatica.genotick.processor.RobotExecutorFactory;
 import com.alphatica.genotick.timepoint.TimePointExecutor;
 import com.alphatica.genotick.timepoint.TimePointExecutorFactory;
 import com.alphatica.genotick.ui.UserOutput;
+import com.alphatica.genotick.utility.TimeCounter;
+
+import static java.lang.String.format;
+import java.util.concurrent.TimeUnit;
 
 public class Simulation {
 
@@ -30,6 +34,7 @@ public class Simulation {
     }
 
     public void start(MainSettings mainSettings, MainAppData data, MainInterface.SessionResult sessionResult) throws IllegalAccessException {
+        TimeCounter simulationRunTime = new TimeCounter("Simulation Run Time", false);
         if(validateSettings(mainSettings)) {
             logSettings(mainSettings);
             RobotKiller killer = createRobotKiller(mainSettings);
@@ -39,6 +44,7 @@ public class Simulation {
             Engine engine = createEngine(mainSettings, data, killer, breeder, population, sessionResult);
             engine.start();
         }
+        System.out.println(format("Simulation finished in %d seconds", simulationRunTime.stop(TimeUnit.SECONDS)));
     }
 
     private boolean validateSettings(MainSettings settings) {

--- a/src/main/java/com/alphatica/genotick/instructions/InstructionList.java
+++ b/src/main/java/com/alphatica/genotick/instructions/InstructionList.java
@@ -1,26 +1,27 @@
 package com.alphatica.genotick.instructions;
 
+import com.alphatica.genotick.genotick.RandomGenerator;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 public class InstructionList implements Serializable {
 
     private static final long serialVersionUID = 267402795981161615L;
 
-    private final Random random;
+    private final RandomGenerator random;
     private final List<Instruction> list;
     private final double[] variables;
 
-    private InstructionList(Random random) {
+    private InstructionList(RandomGenerator random) {
         this.random = random;
         this.list = new ArrayList<>();
         int variablesCount = 1 + Math.abs(random.nextInt() % 1024);
         this.variables = new double[variablesCount];
     }
 
-    public static InstructionList create(Random random) {
+    public static InstructionList create(RandomGenerator random) {
         return new InstructionList(random);
     }
 
@@ -63,7 +64,11 @@ public class InstructionList implements Serializable {
     }
 
     private int validateVariableNumber(int index) {
-        return Math.abs(index % variables.length);
+    	if(index < 0 || index >= variables.length) {
+        	return Math.abs(index % variables.length);
+        } else {
+        	return index;       
+        }
     }
 
     private int fixPosition(int position) {

--- a/src/main/java/com/alphatica/genotick/killer/SimpleRobotKiller.java
+++ b/src/main/java/com/alphatica/genotick/killer/SimpleRobotKiller.java
@@ -3,7 +3,6 @@ package com.alphatica.genotick.killer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 
 import com.alphatica.genotick.genotick.RandomGenerator;
 import com.alphatica.genotick.population.Population;
@@ -12,7 +11,7 @@ import com.alphatica.genotick.ui.UserOutput;
 
 class SimpleRobotKiller implements RobotKiller {
     private RobotKillerSettings settings;
-    private Random random;
+    private RandomGenerator random;
     private final UserOutput output;
 
     private SimpleRobotKiller(UserOutput output) {

--- a/src/main/java/com/alphatica/genotick/mutator/SimpleMutator.java
+++ b/src/main/java/com/alphatica/genotick/mutator/SimpleMutator.java
@@ -7,11 +7,10 @@ import com.alphatica.genotick.processor.Processor;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 class SimpleMutator implements Mutator {
     private MutatorSettings settings;
-    private Random random;
+    private RandomGenerator random;
     private final List<Class< ? super Instruction>> instructionList;
     private int totalInstructions;
 

--- a/src/main/java/com/alphatica/genotick/population/PopulationDAOFactory.java
+++ b/src/main/java/com/alphatica/genotick/population/PopulationDAOFactory.java
@@ -1,18 +1,16 @@
 package com.alphatica.genotick.population;
 
-import java.util.Random;
-
 import com.alphatica.genotick.genotick.RandomGenerator;
 
 public class PopulationDAOFactory {    
     
     public static PopulationDAO getDefaultDAO(PopulationSettings settings) {
         if (settings.daoOption.contains(PopulationDaoOption.RAM)) {
-            Random random = RandomGenerator.create(settings.randomSeed);
+            RandomGenerator random = RandomGenerator.create(settings.randomSeed);
             return new PopulationDAORAM(random);
         }
         else if (settings.daoOption.contains(PopulationDaoOption.DISK)) {
-            Random random = RandomGenerator.create(settings.randomSeed);
+            RandomGenerator random = RandomGenerator.create(settings.randomSeed);
             return new PopulationDAOFileSystem(random, settings.daoPath);
         }
         else {

--- a/src/main/java/com/alphatica/genotick/population/PopulationDAOFileSystem.java
+++ b/src/main/java/com/alphatica/genotick/population/PopulationDAOFileSystem.java
@@ -11,23 +11,24 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
 
+import com.alphatica.genotick.genotick.RandomGenerator;
+
 public class PopulationDAOFileSystem implements PopulationDAO {
     private static final String FILE_EXTENSION = ".prg";
     private final String robotsPath;
-    private final Random random;
+    private final RandomGenerator random;
     private final List<RobotName> names;
 
     public PopulationDAOFileSystem(String path) {
-        this(new Random(), path);
+        this(RandomGenerator.create(0), path);
     }
     
-    public PopulationDAOFileSystem(Random random, String path) {
+    public PopulationDAOFileSystem(RandomGenerator random, String path) {
         checkPath(path);
         this.robotsPath = path;
         this.names = loadRobotNames();
@@ -58,13 +59,16 @@ public class PopulationDAOFileSystem implements PopulationDAO {
     @Override
     public void saveRobot(Robot robot) {
         if(robot.getName() == null) {
-            RobotName name = getAvailableName();
-            robot.setName(name);
-            names.add(name);
+            synchronized(this) {
+                RobotName name = getAvailableName();
+                robot.setName(name);
+                names.add(name);
+                saveRobotToFile(robot);
+            }
+        } else {
+            saveRobotToFile(robot);
         }
-        File file = createFileForName(robot.getName());
-        saveRobotToFile(robot,file);
-    }
+   }
 
     @Override
     public void removeRobot(RobotName robotName) {
@@ -143,7 +147,8 @@ public class PopulationDAOFileSystem implements PopulationDAO {
         return new File(robotsPath + File.separator + name.toString() + FILE_EXTENSION);
     }
 
-    private void saveRobotToFile(Robot robot, File file)  {
+    private void saveRobotToFile(Robot robot)  {
+        File file = createFileForName(robot.getName());
         deleteFileIfExists(file);
         try(ObjectOutputStream ous = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(file)))) {
             ous.writeObject(robot);

--- a/src/main/java/com/alphatica/genotick/population/PopulationDAORAM.java
+++ b/src/main/java/com/alphatica/genotick/population/PopulationDAORAM.java
@@ -1,16 +1,17 @@
 package com.alphatica.genotick.population;
 
+import com.alphatica.genotick.genotick.RandomGenerator;
+
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 import java.util.stream.Stream;
 
 public class PopulationDAORAM implements PopulationDAO {
 
     private final Map<RobotName,Robot> map;
-    private final Random random;
+    private final RandomGenerator random;
 
-    public PopulationDAORAM(Random random) {
+    public PopulationDAORAM(RandomGenerator random) {
         this.map = new HashMap<>();
         this.random = random;
     }
@@ -36,7 +37,7 @@ public class PopulationDAORAM implements PopulationDAO {
     }
 
     @Override
-    public void saveRobot(Robot robot) {
+    public synchronized void saveRobot(Robot robot) {
         if(robot.getName() == null) {
             robot.setName(getAvailableRobotName());
         }

--- a/src/main/java/com/alphatica/genotick/population/Robot.java
+++ b/src/main/java/com/alphatica/genotick/population/Robot.java
@@ -4,6 +4,7 @@ package com.alphatica.genotick.population;
 import com.alphatica.genotick.data.DataSetName;
 import com.alphatica.genotick.genotick.Outcome;
 import com.alphatica.genotick.genotick.Prediction;
+import com.alphatica.genotick.genotick.RandomGenerator;
 import com.alphatica.genotick.genotick.RobotData;
 import com.alphatica.genotick.genotick.RobotDataPair;
 import com.alphatica.genotick.genotick.RobotResult;
@@ -17,7 +18,6 @@ import java.lang.reflect.Modifier;
 import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 
 import static java.util.Optional.ofNullable;
 
@@ -43,7 +43,7 @@ public class Robot implements Serializable {
     private final Map<DataSetName, Prediction> current = new HashMap<>();
     private final Map<DataSetName, Prediction> pending = new HashMap<>();
 
-    public static Robot createEmptyRobot(RobotSettings settings, Random random) {
+    public static Robot createEmptyRobot(RobotSettings settings, RandomGenerator random) {
         return new Robot(settings, random);
     }
 
@@ -201,7 +201,7 @@ public class Robot implements Serializable {
         return bias;
     }
 
-    private Robot(RobotSettings settings, Random random) {
+    private Robot(RobotSettings settings, RandomGenerator random) {
         this.settings = settings;
         this.mainFunction = InstructionList.create(random);
     }

--- a/src/main/java/com/alphatica/genotick/ui/RandomParametersInput.java
+++ b/src/main/java/com/alphatica/genotick/ui/RandomParametersInput.java
@@ -8,11 +8,9 @@ import com.alphatica.genotick.timepoint.TimePoint;
 import com.alphatica.genotick.breeder.InheritedWeightMode;
 import com.alphatica.genotick.chart.GenoChartMode;
 
-import java.util.Random;
-
 class RandomParametersInput extends BasicUserInput {
 
-    private Random random;
+    private RandomGenerator random;
     
     RandomParametersInput(UserOutput output) {
         super(output);

--- a/src/main/java/com/alphatica/genotick/utility/ParallelTasks.java
+++ b/src/main/java/com/alphatica/genotick/utility/ParallelTasks.java
@@ -1,0 +1,26 @@
+package com.alphatica.genotick.utility;
+
+import java.util.function.Consumer;
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+public class ParallelTasks {
+
+    private ParallelTasks() {}
+
+    public static void prepareDefaultThreadPool() {
+    	int poolCores = Math.max(Runtime.getRuntime().availableProcessors()*2, 2);
+    	System.setProperty("java.util.concurrent.ForkJoinPool.common.parallelism", Integer.toString(poolCores));
+    }
+    
+    public static void parallelNumberedTask(int count, Consumer<Integer> action) {
+        Objects.requireNonNull(action);
+        int cores =  Math.max(2, Runtime.getRuntime().availableProcessors());
+        int taskSize = (int)Math.ceil((double)count / (double)cores);
+        IntStream.range(0, count)
+            .filter(blockIndex -> blockIndex % taskSize == 0)
+            .parallel()
+            .forEach(blockIndex -> action.accept(Math.min(taskSize, count-blockIndex)));
+    }
+}
+

--- a/src/main/java/com/alphatica/genotick/utility/TimeCounter.java
+++ b/src/main/java/com/alphatica/genotick/utility/TimeCounter.java
@@ -1,6 +1,7 @@
 package com.alphatica.genotick.utility;
 
 import static java.lang.String.format;
+import java.util.concurrent.TimeUnit;
 
 public class TimeCounter {
     
@@ -29,12 +30,16 @@ public class TimeCounter {
     }
     
     public long stop() {
+        return stop(TimeUnit.NANOSECONDS);
+    }
+    
+    public long stop(TimeUnit timeUnit) {
         stopNanoSeconds = System.nanoTime();
         final long elapsedNanoSeconds = getElapsedNanoSeconds();
         if (printOnStop) {
             print(elapsedNanoSeconds, 2);
         }
-        return elapsedNanoSeconds;
+        return timeUnit.convert(elapsedNanoSeconds, TimeUnit.NANOSECONDS);
     }
     
     public long getElapsedNanoSeconds() {


### PR DESCRIPTION
Population merging support.  Walks multiple population directories and merges the best (and worst) performing robots into a master set.  Will only move a robot that has a abs() score higher than the lowest existing one in the existing master set.